### PR TITLE
Expressjs fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ var express = require('express')
   , linkedin_client = require('linkedin-js')('key', 'secret', 'http://localhost:3003/auth')
   , app = express.createServer(
       express.cookieParser()
-    , express.session()
+    , express.session({ secret: "string" })
     );
 
 app.get('/auth', function (req, res) {

--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ Params must contain the token.
 var express = require('express')
   , linkedin_client = require('linkedin-js')('key', 'secret', 'http://localhost:3003/auth')
   , app = express.createServer(
-      express.cookieDecoder()
+      express.cookieParser()
     , express.session()
     );
 

--- a/lib/linkedin_client.js
+++ b/lib/linkedin_client.js
@@ -22,7 +22,8 @@ module.exports = function (key, secret, redirect) {
     , {'Accept': '*/*', 'Connection': 'close'}
     )
   }
-
+    , paramAppender = "?"
+    , hasParameters = /\/*\?/i
     , _rest_base = 'http://api.linkedin.com/v1';
 
   memoize[key + secret + redirect] = CLIENT;
@@ -58,9 +59,13 @@ module.exports = function (key, secret, redirect) {
 
     if (method.toUpperCase() === 'GET') {
       params.format = 'json';
+      
+      if (path.match(hasParameters)) { 
+          paramAppender = "&";
+      } 
 
       return CLIENT.oauth.get(
-        _rest_base + path + '?' + querystring.stringify(params)
+        _rest_base + path + paramAppender + querystring.stringify(params)
       , token.oauth_token
       , token.oauth_token_secret
       , requestCallback(callback)

--- a/tests/linkedin_test.js
+++ b/tests/linkedin_test.js
@@ -52,5 +52,23 @@ testosterone
     , {token: token, contentType: 'linkedin-html', body: 'hola', '_locale': 'en-US'}
     , callback);
   })
+  
+  .add('`apiCall` GET', function (done) {
+      var callback;
+      
+      gently.expect(linkedin_client.oauth, 'get', function (_path, _token, _secret, _callback) {
+           assert.equal(_path, 'http://api.linkedin.com/v1/people-search?keywords=linkedin&format=json');
+           assert.equal(_token, token.oauth_token);
+           assert.equal(_secret, token.oauth_token_secret);
+           assert.equal(_callback, callback);
+           _callback();
+         });
+
+         callback = gently.expect(function (error, response, body) {
+           done();
+         });
+
+         linkedin_client.apiCall('GET', '/people-search?keywords=linkedin', {token: token}, callback);
+  })
 
   .run();


### PR DESCRIPTION
Hi,

this change set includes some fixes to make the example work with recent
versions of express js and a bugfix to an issue with specifying a data return format to parametrized requests.

By default the string "?format=json" is appended to all paths before sending a GET request; this needs to be changed to "&format=json" if one or more parameters have been already specified by a user in apiCall. 

 Commit 76c21095cb12440d6f32f5d9855507b9283f761d includes a regexp to test against the pattern "/\/*\?/". If the patch matches, an '&' is prepended to "format=json". '?' is used  otherwise (default value).
