### PR TITLE
Fix: use the correct token to sign requests in the code example.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,8 @@ app.get('/auth', function (req, res) {
   // the first time will redirect to linkedin
   linkedin_client.getAccessToken(req, res, function (error, token) {
     // will enter here when coming back from linkedin
+    req.session.token = token;
+    
     res.render('auth');
   });
 });
@@ -40,8 +42,8 @@ app.post('/message', function (req, res) {
   linkedin_client.apiCall('POST', '/people/~/shares',
     {
       token: {
-        oauth_token_secret: req.param('oauth_token_secret')
-      , oauth_token: req.param('oauth_token')
+        oauth_token_secret: req.session.token.oauth_token_secret
+      , oauth_token: req.session.token.oauth_token
       }
     , share: {
         comment: req.param('message')


### PR DESCRIPTION
During the oauth dance two tokens pairs are generated and saved into a session;
getAccessToken() passes the most recent token/token_secret pair to the callback
function. This couple is the actual access token that needs to be saved in the current
session and has to be used to sign futher requests.

See: https://developer.linkedin.com/documents/getting-oauth-token
